### PR TITLE
Fixed app load bug where checked for notepad instead of halo 5 forge

### DIFF
--- a/Corps H5F Tool/H5_Tool.cs
+++ b/Corps H5F Tool/H5_Tool.cs
@@ -27,7 +27,7 @@ namespace Corps_H5F_Tool
             ResTrackBar.Maximum = 7680;
             FPSTrackBar.Minimum = 30;
             FPSTrackBar.Maximum = 300;
-            Process[] pname = Process.GetProcessesByName("notepad");
+            Process[] pname = Process.GetProcessesByName("halo5forge");
             if (pname.Length == 0)
             {
                 FovInput.Value = 78;


### PR DESCRIPTION
Fixed a bug on application load where it was checking the existence of notepad rather than halo 5 forge.
